### PR TITLE
Unify behaviour regarding virtual remotes and add query parameter

### DIFF
--- a/xmlapi/index.cgi
+++ b/xmlapi/index.cgi
@@ -32,7 +32,8 @@ if {[info exists sid] && [check_session $sid]} {
     <tr><td><a href=./checkuptodate.cgi?sid=$sid>checkuptodate.cgi</a></td><td>????</td></tr>
     <tr><td><a href=./devicelist.cgi?sid=$sid>devicelist.cgi</a></td><td><b>Lists all devices with channels. Contain names, serial number, device type and ids.</b><br/>
       <i>sid=string</i> - security access token id<br/>
-      <i>show_internal=0/1</i> - adds internal channels also (default=0)
+      <i>show_internal=0/1</i> - adds internal channels also (default=0)<br/>
+      <i>show_remote=0/1</i> - adds output of virtual remote channels (default=0)
     </td></tr>
     <tr><td><a href=./devicetypelist.cgi?sid=$sid>devicetypelist.cgi</a></td><td><b>Lists all possible device types with their possible meta data.</b><br/>
       <i>sid=string</i> - security access token id<br/>
@@ -101,7 +102,8 @@ if {[info exists sid] && [check_session $sid]} {
     <tr><td><a href=./statelist.cgi?sid=$sid>statelist.cgi</a></td><td><b>Outputs all devices with channels and their current values.</b><br/>
       <i>sid=string</i> - security access token id<br/>
       <i>ise_id=int</i> - output only channels and values of device with specified id (e.g. "1234")<br/>
-      <i>show_internal=0/1</i> - adds internal channels also (default=0)
+      <i>show_internal=0/1</i> - adds internal channels also (default=0)<br/>
+      <i>show_remote=0/1</i> - adds output of virtual remote channels (default=0)
     </td></tr>
     <tr><td><a href=./systemNotification.cgi?sid=$sid>systemNotification.cgi</a></td><td><b>Outputs the currently existing system notifications.</b><br/>
       <i>sid=string</i> - security access token id<br/>

--- a/xmlapi/statelist.cgi
+++ b/xmlapi/statelist.cgi
@@ -9,6 +9,7 @@ if {[info exists sid] && [check_session $sid]} {
 
   set ise_id 0
   set show_internal 0
+  set show_remote 0
   catch {
     set input $env(QUERY_STRING)
     set pairs [split $input &]
@@ -21,11 +22,16 @@ if {[info exists sid] && [check_session $sid]} {
         set show_internal $val
         continue
       }
+      if {0 != [regexp "^show_remote=(.*)$" $pair dummy val]} {
+        set show_remote $val
+        continue
+      }
     }
   }
 
   set comm "var ise_id=$ise_id;\n"
   append comm "var show_internal=$show_internal;\n"
+  append comm "var show_remote=$show_remote;\n"
 
   if { $ise_id != 0 } then {
 
@@ -64,7 +70,9 @@ if {[info exists sid] && [check_session $sid]} {
       {
         object oDevice = dom.GetObject(sDevId);
 
-        if( oDevice.ReadyConfig() && (oDevice.Name() != "Zentrale") && (oDevice.Name() != "HMW-RCV-50 BidCoS-Wir") )
+        boolean isRemote = ( ("HMW-RCV-50" == oDevice.HssType()) || ("HM-RCV-50" == oDevice.HssType() ) );
+
+        if( oDevice.ReadyConfig() && ( ( isRemote == false ) || ( show_remote == 1 ) ) )
         {
           Write("<device");
           Write(" name='" # oDevice.Name() # "'");


### PR DESCRIPTION
Previously devicelist.cgi and statelist.cgi handled virtual remotes differently. devicelist.cgi ommited these channels based on the type of the device, statelist.cgi used the name of the device to achieve the same, which yielded inconsitent behaviour. Now the device type is used in both scripts. This breaks the possiblity to receive the workaround to receive the virtual remote in statelist.cgi by renaming the device.

Therefore this also adds a query parameter show_remote to both scripts to reliably receive the virtual remote channels.