### PR TITLE
Adding user session check to exec.cgi

### DIFF
--- a/xmlapi/exec.cgi
+++ b/xmlapi/exec.cgi
@@ -1,6 +1,8 @@
 #!/bin/tclsh
 
 load tclrega.so
+source querystring.tcl
+source session.tcl
 
 proc toString { str } {
   set map {
@@ -22,22 +24,26 @@ puts "Content-Type: text/plain"
 puts "Access-Control-Allow-Origin: *"
 puts ""
 
-
-if { [catch {
-  set content [read stdin]
-  array set script_result [rega_script $content]
-
-  set first 1
-  set result "\{\n"
-  foreach name [array names script_result] {
-    if { 1 != $first } { append result ",\n" } { set first 0 }
-    set value $script_result($name)
-    append result "  [toString $name]: [toString $value]"
+if {[info exists sid] && [check_session $sid]} {
+  if { [catch {
+    set content [read stdin]
+    array set script_result [rega_script $content]
+  
+    set first 1
+    set result "\{\n"
+    foreach name [array names script_result] {
+      if { 1 != $first } { append result ",\n" } { set first 0 }
+      set value $script_result($name)
+      append result "  [toString $name]: [toString $value]"
+    }
+    append result "\n\}"
+  
+    puts $result
+  
+  } errorMessage] } {
+    puts $errorMessage
   }
-  append result "\n\}"
 
-  puts $result
-
-} errorMessage] } {
-  puts $errorMessage
+} else {
+    puts "{error: no session}"
 }

--- a/xmlapi/querystring.tcl
+++ b/xmlapi/querystring.tcl
@@ -1,0 +1,9 @@
+catch {
+  set input $env(QUERY_STRING)
+  set pairs [split $input &]
+  foreach pair $pairs {
+    if {0 != [regexp "^(\[^=]*)=(.*)$" $pair dummy varname val]} {
+      set $varname $val
+    }
+  }
+}

--- a/xmlapi/session.tcl
+++ b/xmlapi/session.tcl
@@ -1,0 +1,13 @@
+#!/bin/tclsh
+
+load tclrega.so
+
+proc check_session sid {
+    if {[regexp {@([0-9a-zA-Z]{10})@} $sid all sidnr]} {
+        set res [lindex [rega_script "Write(system.GetSessionVarStr('$sidnr'));"] 1]
+        if {$res != ""} {
+            return 1
+        }
+    }
+    return 0
+}


### PR DESCRIPTION
This change adds a first version of user session check and validation.
Login in WegUI to get a valid sessionID to be able to call
```/addons/xmlapi/exec.cgi?sid=....```

ToDo: User authorisation level check (Admin, User or Guest) needs to be
added.
Currently the guest level can use the script, too.
But better a valid login session than nothing.

Disclaimer: I just added the login session check as a kind of proof of
concept. I did not check any negative impact to existing tools or
scripts.

Both TCL scripts were copied from
https://github.com/rdmtc/RedMatic/tree/master/addon_files/redmatic/lib/