### PR TITLE
Whitespaces enabled in token description

### DIFF
--- a/xmlapi/tokenregister.cgi
+++ b/xmlapi/tokenregister.cgi
@@ -14,7 +14,28 @@ if {[info exists sid] && [check_session $sid]} {
     set pairs [split $input &]
     foreach pair $pairs {
       if {0 != [regexp "^desc=(.*)$" $pair dummy val]} {
-        set desc [regsub -all "%20" $val " "]
+        set desc $val
+
+        # replace URL encoded parts
+        regsub -all {%20} $desc { } desc
+        regsub -all {%21} $desc {!} desc
+        regsub -all {%23} $desc {#} desc
+        regsub -all {%25} $desc {%} desc
+        regsub -all {%25} $desc {%} desc
+        regsub -all {%2A} $desc  *  desc
+        regsub -all {%2F} $desc {/} desc
+        regsub -all {%3F} $desc {?} desc
+        regsub -all {%5E} $desc {^} desc
+        regsub -all {%3D} $desc {=} desc
+        regsub -all {%2C} $desc {,} desc
+
+        # disable certain invalid chars
+        regsub -all {%3C} $desc {_} desc
+        regsub -all {<}   $desc {_} desc
+        regsub -all {%3E} $desc {_} desc
+        regsub -all {>}   $desc {_} desc
+        regsub -all {%27} $desc {_} desc
+        regsub -all {'}   $desc {_} desc
         break
       }
     }

--- a/xmlapi/tokenregister.cgi
+++ b/xmlapi/tokenregister.cgi
@@ -14,7 +14,7 @@ if {[info exists sid] && [check_session $sid]} {
     set pairs [split $input &]
     foreach pair $pairs {
       if {0 != [regexp "^desc=(.*)$" $pair dummy val]} {
-        set desc $val
+        set desc [regsub -all "%20" $val " "]
         break
       }
     }


### PR DESCRIPTION
This change allows whitespaces to be used in the token description